### PR TITLE
Moyaを削除

### DIFF
--- a/Linktape.xcodeproj/project.pbxproj
+++ b/Linktape.xcodeproj/project.pbxproj
@@ -6,10 +6,6 @@
 	objectVersion = 77;
 	objects = {
 
-/* Begin PBXBuildFile section */
-		D9E9AA8C2E3F6D2600976E8B /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = D9E9AA8B2E3F6D2600976E8B /* Moya */; };
-/* End PBXBuildFile section */
-
 /* Begin PBXContainerItemProxy section */
 		D9E24BF42E114C8500FC5331 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -56,7 +52,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D9E9AA8C2E3F6D2600976E8B /* Moya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,7 +112,6 @@
 			);
 			name = Linktape;
 			packageProductDependencies = (
-				D9E9AA8B2E3F6D2600976E8B /* Moya */,
 			);
 			productName = Linktape;
 			productReference = D9E24BE62E114C8300FC5331 /* Linktape.app */;
@@ -202,7 +196,6 @@
 			mainGroup = D9E24BDD2E114C8300FC5331;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				D9E9AA8A2E3F6D2600976E8B /* XCRemoteSwiftPackageReference "Moya" */,
 				D9E9AA8D2E3F6E0000976E8B /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -566,14 +559,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		D9E9AA8A2E3F6D2600976E8B /* XCRemoteSwiftPackageReference "Moya" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Moya/Moya.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 15.0.3;
-			};
-		};
 		D9E9AA8D2E3F6E0000976E8B /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
@@ -583,14 +568,6 @@
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		D9E9AA8B2E3F6D2600976E8B /* Moya */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D9E9AA8A2E3F6D2600976E8B /* XCRemoteSwiftPackageReference "Moya" */;
-			productName = Moya;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = D9E24BDE2E114C8300FC5331 /* Project object */;
 }

--- a/Linktape.xcodeproj/project.pbxproj
+++ b/Linktape.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -396,6 +397,7 @@
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Linktape.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Linktape.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,42 +1,6 @@
 {
-  "originHash" : "6c3743b4e38be7ecce4c041fd0aacfec7f1500fed61aca6067255cbe27929190",
+  "originHash" : "1fa961aa1dc717cea452f3389668f0f99a254f07e4eb11d190768a53798f744f",
   "pins" : [
-    {
-      "identity" : "alamofire",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire.git",
-      "state" : {
-        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
-        "version" : "5.10.2"
-      }
-    },
-    {
-      "identity" : "moya",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Moya/Moya.git",
-      "state" : {
-        "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
-        "version" : "15.0.3"
-      }
-    },
-    {
-      "identity" : "reactiveswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
-      "state" : {
-        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
-        "version" : "6.7.0"
-      }
-    },
-    {
-      "identity" : "rxswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ReactiveX/RxSwift.git",
-      "state" : {
-        "revision" : "5dd1907d64f0d36f158f61a466bab75067224893",
-        "version" : "6.9.0"
-      }
-    },
     {
       "identity" : "swiftlintplugins",
       "kind" : "remoteSourceControl",


### PR DESCRIPTION
`@unchecked Sendable`や`preconcurrency`を使いたくなかった。
MoyaはSendableでないため、削除して自作のSendableなAPIClientを作成することにした。